### PR TITLE
youtube-viewer: update to 3.10.9

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -1,8 +1,8 @@
 name       : youtube-viewer
-version    : 3.10.8
-release    : 40
+version    : 3.10.9
+release    : 41
 source     :
-    - https://github.com/trizen/youtube-viewer/archive/refs/tags/3.10.8.tar.gz : 010e2af3337842b039f9e582330a5ac0ffa1bf94b53bed016e4a07049f3a6b94
+    - https://github.com/trizen/youtube-viewer/archive/refs/tags/3.10.9.tar.gz : e3593324176f5f8dd82e72936fcc1b529f85b88acc16000e1f1133b417590775
 homepage   : https://github.com/trizen/youtube-viewer
 license    : Artistic-2.0
 component  : network.web
@@ -15,6 +15,7 @@ builddeps  :
 rundeps    :
     - libwww-perl
     - mpv
+    - perl-clone
     - perl-file-sharedir
     - perl-gtk2
     - perl-gtk3
@@ -31,3 +32,5 @@ install    : |
     install -Dm00644 $workdir/share/icons/gtk-youtube-viewer.png $installdir/usr/share/pixmaps/gtk-youtube-viewer.png
 check      : |
     $workdir/Build test
+patterns   :
+    - /*

--- a/pspec_x86_64.xml
+++ b/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>youtube-viewer</Name>
         <Homepage>https://github.com/trizen/youtube-viewer</Homepage>
         <Packager>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>Artistic-2.0</License>
         <PartOf>network.web</PartOf>
@@ -71,12 +71,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="40">
-            <Date>2023-07-29</Date>
-            <Version>3.10.8</Version>
+        <Update release="41">
+            <Date>2023-09-14</Date>
+            <Version>3.10.9</Version>
             <Comment>Packaging update</Comment>
-            <Name>Algent Albrahimi</Name>
-            <Email>algent@protonmail.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Changes:**
- Re-implemented support for related videos, without using the YouTube API
- Added the `subscription_videos_per_channel` config-option

**Packaging Changes:**
- Added catch-all pattern to prevent creation of -devel with man files
- Added `perl-clone` dependency

**Test Plan:**
- Searched and watched videos using CLI app
- Searched and watched videos using GTK/GUI app

### Checklist

- [x] Package was built and tested against unstable
